### PR TITLE
Fixes Password reset confirm

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -195,7 +195,6 @@ def password_reset_confirm(request, uidb64=None, token=None,
     form for entering a new password.
     """
     UserModel = get_user_model()
-    assert uidb64 is not None and token is not None  # checked by URLconf
     if post_reset_redirect is None:
         post_reset_redirect = reverse('django.contrib.auth.views.password_reset_complete')
     try:

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -199,8 +199,8 @@ def password_reset_confirm(request, uidb64=None, token=None,
         post_reset_redirect = reverse('django.contrib.auth.views.password_reset_complete')
     try:
         uid = urlsafe_base64_decode(str(uidb64))
-        user = User.objects.get(id=uid)
-    except (TypeError, ValueError, User.DoesNotExist):
+        user = UserModel._default_manager.get(id=uid)
+    except (TypeError, ValueError, UserModel.DoesNotExist):
         user = None
 
     if user is not None and token_generator.check_token(user, token):

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -209,7 +209,7 @@ def urlsafe_base64_encode(s):
 def urlsafe_base64_decode(s):
     assert isinstance(s, str)
     try:
-        return base64.urlsafe_b64decode(s.ljust(len(s) + len(s) % 4, '='))
+        return base64.urlsafe_b64decode(s.ljust(len(s) + len(s) % 4, str('=')))
     except (LookupError, BinasciiError), e:
         raise ValueError(e)
 


### PR DESCRIPTION
Hey,

This patch will fix `django.contrib.auth.views.password_reset_confirm` view.
Without this password reset won't work at all due to couple of wrong `type` conversion.
Anyway, this patch is already working on a live production env.
