### PR TITLE
fixed syntax of an exception for python 3 compatibility

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -210,7 +210,7 @@ def urlsafe_base64_decode(s):
     assert isinstance(s, str)
     try:
         return base64.urlsafe_b64decode(s.ljust(len(s) + len(s) % 4, str('=')))
-    except (LookupError, BinasciiError), e:
+    except (LookupError, BinasciiError) as e:
         raise ValueError(e)
 
 def parse_etags(etag_str):


### PR DESCRIPTION
One of the patches for django to add nonrel support broke python 3 compatibility by using an old syntax.

See http://www.python.org/dev/peps/pep-3110/ for details on the grammar change, but in short, the `except LookupError, e:` would be replaced with `except LookupError as e:`.
