### PR TITLE
Fix default Site ID to use settings.SITE_ID

### DIFF
--- a/django/contrib/sites/management.py
+++ b/django/contrib/sites/management.py
@@ -5,6 +5,7 @@ Creates the default Site object.
 from django.db.models import signals
 from django.db import connections
 from django.db import router
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.contrib.sites import models as site_app
 from django.core.management.color import no_style
@@ -19,7 +20,7 @@ def create_default_site(app, created_models, verbosity, db, **kwargs):
         # can also crop up outside of tests - see #15346.
         if verbosity >= 2:
             print("Creating example.com Site object")
-        Site(pk=1, domain="example.com", name="example.com").save(using=db)
+        Site(pk=settings.SITE_ID, domain="example.com", name="example.com").save(using=db)
 
         # We set an explicit pk instead of relying on auto-incrementation,
         # so we need to reset the database sequence. See #17415.


### PR DESCRIPTION
This fixes syncdb when using mongodb-engine as the default SITE_ID=1 is
not a valid ObjectID in MongoDB. Setting a valid SITE_ID is already
suggested by mongodb-engine, but it does not have any effect if the
SITE_ID is hardcoded for the default site.
